### PR TITLE
Support for other S3 backends

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -7,5 +7,4 @@ ignore:
   - "C:/*"
   - "../*"
   - src/lib.rs
-  - src/client.rs
   - "src/mock/*"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: sudo apt update && sudo apt install -y libssh2-1-dev libssl-dev
+      - name: Setup containers
+        run: docker-compose -f "tests/docker-compose.yml" up -d --build
       - name: Setup nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -22,7 +24,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --lib --no-default-features --features find,github-actions --no-fail-fast
+          args: --lib --no-default-features --features find,github-actions,with-containers --no-fail-fast
         env:
           RUST_LOG: trace
           CARGO_INCREMENTAL: "0"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: sudo apt update && sudo apt install -y libssh2-1-dev libssl-dev
+      - name: Setup containers
+        run: docker-compose -f "tests/docker-compose.yml" up -d --build
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -22,7 +24,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features --features find,github-actions --no-fail-fast
+          args: --no-default-features --features find,github-actions,with-containers --no-fail-fast
         env:
           RUST_LOG: trace
       - name: Format

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,10 +27,33 @@
 //! use remotefs_aws_s3::AwsS3Fs;
 //! use std::path::Path;
 //!
-//! let mut client = AwsS3Fs::new("test-bucket", "eu-west-1")
+//! let mut client = AwsS3Fs::new("test-bucket")
+//!     .region("eu-west-1")
 //!     .profile("default")
 //!     .access_key("AKIAxxxxxxxxxxxx")
 //!     .secret_access_key("****************");
+//! // connect
+//! assert!(client.connect().is_ok());
+//! // get working directory
+//! println!("Wrkdir: {}", client.pwd().ok().unwrap().display());
+//! // change working directory
+//! assert!(client.change_dir(Path::new("/tmp")).is_ok());
+//! // disconnect
+//! assert!(client.disconnect().is_ok());
+//! ```
+//!
+//! ### MinIO client
+//!
+//! ```rust,ignore
+//! use remotefs::RemoteFs;
+//! use remotefs_aws_s3::AwsS3Fs;
+//! use std::path::Path;
+//!
+//! let mut client = AwsS3Fs::new("test-bucket")
+//!     .endpoint("http://localhost:9000")
+//!     .new_path_style(true) // required for MinIO
+//!     .access_key("minioadmin")
+//!     .secret_access_key("minioadmin");
 //! // connect
 //! assert!(client.connect().is_ok());
 //! // get working directory

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -28,7 +28,7 @@
 
 // -- logger
 
-#[cfg(feature = "with-s3-ci")]
+#[cfg(any(feature = "with-s3-ci", feature = "with-containers"))]
 pub fn logger() {
     let _ = env_logger::builder().is_test(true).try_init();
 }

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+  minio-server:
+    image: minio/minio
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    command: server /data --console-address ":9001"


### PR DESCRIPTION
# Support for other S3 backends

## Description

- Added new options to provide support for S3 compatible backends, such as minio
- Added test units with containers, using minio.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] The changes I've made are Windows, MacOS, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [x] regression test: aws-s3 tests
- [x] test units with minio
